### PR TITLE
Routes auto loading improvement, and routes optimization.

### DIFF
--- a/src/middlewares/uploadArray.js
+++ b/src/middlewares/uploadArray.js
@@ -1,0 +1,11 @@
+const multer = require('multer');
+
+const storage = multer.memoryStorage({
+  destination: function (req, file, cb) {
+    cb(null, '')
+  },
+})
+  
+const upload = multer({ storage: storage }).array('image')
+
+module.exports = upload;

--- a/src/middlewares/uploadSingle.js
+++ b/src/middlewares/uploadSingle.js
@@ -1,0 +1,11 @@
+const multer = require('multer');
+
+const storage = multer.memoryStorage({
+  destination: function (req, file, cb) {
+    cb(null, '')
+  },
+})
+  
+const upload = multer({ storage: storage }).single('image');
+
+module.exports = upload;

--- a/src/pg/config.js
+++ b/src/pg/config.js
@@ -3,7 +3,7 @@ const Sequelize = require('sequelize');
 
 const PGUSER = process.env.PGUSER;
 const PGPASSWORD = process.env.PGPASSWORD;
-const PGPORT = process.env.PGPOST;
+const PGPORT = process.env.PGPORT;
 const PGHOST = process.env.PGHOST;
 const PGDATABASE = process.env.PGDATABASE;
 
@@ -13,6 +13,7 @@ client.connect();
 
 const sequelize = new Sequelize(PGDATABASE, PGUSER, PGPASSWORD, {
   host: PGHOST,
+  port: PGPORT,
   dialect: 'postgres'
 });
 

--- a/src/routes-loader.js
+++ b/src/routes-loader.js
@@ -13,6 +13,7 @@ const routesLoader = (app, directory) => {
 const loadRoutesOnExpressApp = (app, directory) => {
     const routesRootPath = path.join(__dirname, directory);
     console.log(`Auto loading routes from ${directory}`);
+    console.log('API endpoint => route directory');
     fs.readdirSync(routesRootPath).forEach(f => {
         const routesDirs = [];
         if (fs.lstatSync(path.resolve(routesRootPath, f)).isDirectory()) {
@@ -20,9 +21,11 @@ const loadRoutesOnExpressApp = (app, directory) => {
         }
         // Go through each of the directories inside routes
         routesDirs.forEach(rd => {
+            // Converts camelCase into camel-case
+            const formattedRoute = rd.replace(/[A-Z]/g, m => "-" + m.toLowerCase());
             const routeDir = `${directory}/${rd}`;
-            console.log(`${routeDir}`);
-            app.use('/', require(routeDir));
+            console.log(`/${formattedRoute} => ${routeDir}`);
+            app.use(`/${formattedRoute}`, require(routeDir));
         });
     });
 }

--- a/src/routes/adminlogin/index.js
+++ b/src/routes/adminlogin/index.js
@@ -1,11 +1,9 @@
 const router = require('express').Router();
 const cors = require('cors');
-const multer = require('multer');
-const fs = require('fs');
 const jwt = require('jsonwebtoken');
-const config = require('../../config.js');
 const bcrypt = require('bcryptjs');
 const User = require('../../pg/models/Users');
+const upload = require('../../middlewares/uploadSingle');
 const UserAddress = require('../../pg/models/UserAddresses');
 
 const AWS = require('aws-sdk');
@@ -15,15 +13,7 @@ const { cleanData } = require('../../utils');
 
 router.all('*', cors());
 
-var storage = multer.memoryStorage({
-  destination: function (req, file, cb) {
-    cb(null, '')
-  },
-})
-
-var upload = multer({ storage: storage }).single('image')
-
-router.post('/adminlogin', upload, async(req, res, next) => {
+router.post('/', upload, async(req, res, next) => {
   const body = req.body;
   const cleandata = cleanData(body.email);
   if (cleandata) {

--- a/src/routes/bannerImages/index.js
+++ b/src/routes/bannerImages/index.js
@@ -1,12 +1,10 @@
 const router = require('express').Router();
 const cors = require('cors');
-const config = require('../../config.js');
-
 const BannerImg = require('../../pg/models/BannerImg');
 
 router.all('*', cors());
 
-router.delete('/banner-images', (req, res, next) => {
+router.delete('/', (req, res, next) => {
   // delete brands
   client.query('SELECT * FROM banner_images where id = $1', [1], function (err, result) {
       if (err) {
@@ -16,15 +14,15 @@ router.delete('/banner-images', (req, res, next) => {
   });
 });
 
-router.post('/banner-images', (req, res, next) => {
+router.post('/', (req, res, next) => {
   console.log("receive",req)
   // Employee.create(req.body.form).then((employee) => {
   //   res.status(200).json(employee);
   // });
 });
 
-router.get('/banner-images', async(req, res, next) => {
-  BannerImage.findAll({ include: ['BannerImageBanner']}).then((bimage) => {
+router.get('/', async(req, res, next) => {
+  BannerImg.findAll({ include: ['BannerImageBanner']}).then((bimage) => {
     res.status(200).json(bimages);
   }).catch((err) => {
     res.send({status: false, message: err})

--- a/src/routes/banners/index.js
+++ b/src/routes/banners/index.js
@@ -1,11 +1,8 @@
 const router = require('express').Router();
 const cors = require('cors');
-const multer = require('multer');
-const fs = require('fs');
-const config = require('../../config.js');
 const verify = require('../verifyToken');
 const Banner = require('../../pg/models/banners');
-// const BannerImages = require('../../pg/models/BannerImages');
+const upload = require('../../middlewares/uploadArray');
 
 const AWS = require('aws-sdk');
 const uuid = require('uuid');
@@ -14,19 +11,11 @@ const s3 = new AWS.S3({
   secretAccessKey: process.env.AWS_SECRET
 })
 
-var storage = multer.memoryStorage({
-  destination: function (req, file, cb) {
-    cb(null, '')
-  },
-})
-
-var upload = multer({ storage: storage }).array('image')
-
 const aw3Bucket = `${process.env.AWS_BUCKET_NAME}/slideImages`;
 
 router.all('*', cors());
 
-router.delete('/banners/:id', verify, (req, res, next) => {
+router.delete('/:id', verify, (req, res, next) => {
   // delete products
   Banner.findAll({ where: {id: req.params.id},include:['productImages', 'bannerStatus']})
   .then((banner) => {
@@ -64,7 +53,7 @@ router.delete('/banners/:id', verify, (req, res, next) => {
   })
 });
 
-router.get('/banners', async(req, res, next) => {
+router.get('/', async(req, res, next) => {
   // get statuses
   let banner = null;
   console.log("query ", req.query)
@@ -92,9 +81,7 @@ router.get('/banners', async(req, res, next) => {
   }
 });
 
-router.put('/banners/:id', [verify, upload], (req, res, next) => {
-
-
+router.put('/:id', [verify, upload], (req, res, next) => {
   const imagesUploaded = req.files.map((file) => {
     let myFile = file.originalname.split('.');
     const fileType = myFile[myFile.length - 1];
@@ -208,7 +195,7 @@ router.put('/banners/:id', [verify, upload], (req, res, next) => {
   })
 });
 
-router.post('/banners', [verify, upload], (req, res, next) => {
+router.post('/', [verify, upload], (req, res, next) => {
   // add / update products
   const imagesUploaded = req.files.map((file) => {
     let myFile = file.originalname.split('.');

--- a/src/routes/bannertypes/index.js
+++ b/src/routes/bannertypes/index.js
@@ -4,12 +4,12 @@ const BannerType = require('../../pg/models/BannerTypes');
 
 router.all('*', cors());
 
-router.get('/bannertypes/:id', async(req, res, next) => {
+router.get('/:id', async(req, res, next) => {
     let bannerType = await BannerType.findOne({ where: {id: req.params.id}, include: ['bannerTypeStatus']});
     res.json(bannerType)
 });
 
-router.get('/bannertypes', async(req, res, next) => {
+router.get('/', async(req, res, next) => {
   // get statuses
   let bannerType = null;
   if (req.query.id) {

--- a/src/routes/brands/index.js
+++ b/src/routes/brands/index.js
@@ -1,11 +1,8 @@
 const router = require('express').Router();
 const cors = require('cors');
-const multer = require('multer');
-const fs = require('fs');
-const config = require('../../config.js');
 const verify = require('../verifyToken');
 const Brand = require('../../pg/models/Brands');
-
+const upload = require('../../middlewares/uploadSingle');
 const AWS = require('aws-sdk');
 const uuid = require('uuid');
 
@@ -16,17 +13,9 @@ const s3 = new AWS.S3({
 
 router.all('*', cors());
 
-var storage = multer.memoryStorage({
-  destination: function (req, file, cb) {
-    cb(null, '')
-  },
-})
-
-var upload = multer({ storage: storage }).single('image')
-
 const aw3Bucket = `${process.env.AWS_BUCKET_NAME}/brands`;
 
-router.delete('/brands/:id', verify,  (req, res, next) => {
+router.delete('/:id', verify,  (req, res, next) => {
   // delete brands
   Brand.findAll({ where: {id: req.params.id}})
   .then((brand) => {
@@ -56,7 +45,7 @@ router.delete('/brands/:id', verify,  (req, res, next) => {
 });
 
 
-router.put('/brands/:id', [verify, upload], (req, res, next) => {
+router.put('/:id', [verify, upload], (req, res, next) => {
   let dataInsert = null;
   const body = req.body;
   const bid = req.params.id;
@@ -120,7 +109,7 @@ router.put('/brands/:id', [verify, upload], (req, res, next) => {
   })
 });
 
-router.post('/brands', [verify, upload], (req, res, next) => {
+router.post('/', [verify, upload], (req, res, next) => {
   let dataEntry = null;
   const body = req.body;
   
@@ -156,12 +145,12 @@ router.post('/brands', [verify, upload], (req, res, next) => {
   })
 })
 
-router.get('/brands/:id', async(req, res, next) => {
-    let brand = await Brand.findAll({ where: {id: req.params.id}, include:['brandStatus']});
+router.get('/:id', async(req, res, next) => {
+    const brand = await Brand.findAll({ where: {id: req.params.id}, include:['brandStatus']});
     res.json(brand)
 });
 
-router.get('/brands', async(req, res, next) => {
+router.get('/', async(req, res, next) => {
   // get products
   let brand = null;
   if (req.query.id) {

--- a/src/routes/categories/index.js
+++ b/src/routes/categories/index.js
@@ -1,23 +1,12 @@
 const router = require('express').Router();
 const cors = require('cors');
-const multer = require('multer');
-const fs = require('fs');
-const config = require('../../config.js');
 const verify = require('../verifyToken');
-
+const upload = require('../../middlewares/uploadSingle');
 const Category = require('../../pg/models/Categories');
 
 router.all('*', cors());
 
-var storage = multer.memoryStorage({
-  destination: function (req, file, cb) {
-    cb(null, '')
-  },
-})
-
-var upload = multer({ storage: storage }).single('image')
-
-router.delete('/categories/:id', verify, (req, res, next) => {
+router.delete('/:id', verify, (req, res, next) => {
   // delete brands
   Category.findAll({ where: {id: req.params.id}})
   .then((brand) => {
@@ -33,8 +22,7 @@ router.delete('/categories/:id', verify, (req, res, next) => {
   })
 });
 
-router.put('/categories/:id', [verify, upload], (req, res, next) => {
-  let dataInsert = null;
+router.put('/:id', [verify, upload], (req, res, next) => {
   const body = req.body;
   const bid = req.params.id;
   
@@ -59,8 +47,7 @@ router.put('/categories/:id', [verify, upload], (req, res, next) => {
   })
 });
 
-router.post('/categories', verify, upload, (req, res, next) => {
-  let dataEntry = null;
+router.post('/', verify, upload, (req, res, next) => {
   const body = req.body;
 
   Category.create({
@@ -73,12 +60,12 @@ router.post('/categories', verify, upload, (req, res, next) => {
   })
 })
 
-router.get('/categories/:id', async(req, res, next) => {
-    let category = await Category.findAll({ where: {id: req.params.id}});
+router.get('/:id', async(req, res, next) => {
+    const category = await Category.findAll({ where: {id: req.params.id}});
     res.json(category)
 });
 
-router.get('/categories', async(req, res, next) => {
+router.get('/', async(req, res, next) => {
   // get products
   let category = null;
   if (req.query.id) {

--- a/src/routes/countries/index.js
+++ b/src/routes/countries/index.js
@@ -1,14 +1,10 @@
 const router = require('express').Router();
 const cors = require('cors');
-const multer = require('multer');
-const fs = require('fs');
-const config = require('../../config.js');
-
 const Country = require('../../pg/models/Countries');
 
 router.all('*', cors());
 
-router.get('/countries', async(req, res, next) => {
+router.get('/', async(req, res, next) => {
   // get statuses
   let country = null;
   if (req.query.id) {

--- a/src/routes/genders/index.js
+++ b/src/routes/genders/index.js
@@ -1,14 +1,10 @@
 const router = require('express').Router();
 const cors = require('cors');
-const multer = require('multer');
-const fs = require('fs');
-const config = require('../../config.js');
-
 const Gender = require('../../pg/models/Genders');
 
 router.all('*', cors());
 
-router.get('/genders', async(req, res, next) => {
+router.get('/', async(req, res, next) => {
   // get statuses
   let gender = null;
   if (req.query.id) {

--- a/src/routes/login/index.js
+++ b/src/routes/login/index.js
@@ -1,27 +1,14 @@
 const router = require('express').Router();
 const cors = require('cors');
-const multer = require('multer');
-const fs = require('fs');
 const jwt = require('jsonwebtoken');
-const config = require('../../config.js');
 const bcrypt = require('bcryptjs');
 const User = require('../../pg/models/Users');
-const { cleanData } = require('../../utils')
-
-const AWS = require('aws-sdk');
-const uuid = require('uuid');
+const { cleanData } = require('../../utils');
+const upload = require('../../middlewares/uploadSingle');
 
 router.all('*', cors());
 
-var storage = multer.memoryStorage({
-  destination: function (req, file, cb) {
-    cb(null, '')
-  },
-})
-
-var upload = multer({ storage: storage }).single('image')
-
-router.post('/login', upload, async(req, res, next) => {
+router.post('/', upload, async(req, res, next) => {
   const body = req.body;
 
   if (body.email) {

--- a/src/routes/productImages/index.js
+++ b/src/routes/productImages/index.js
@@ -1,12 +1,10 @@
 const router = require('express').Router();
 const cors = require('cors');
-const config = require('../../config.js');
-
 const ProductImage = require('../../pg/models/ProductImages');
 
 router.all('*', cors());
 
-router.delete('/product-images', (req, res, next) => {
+router.delete('/', (req, res, next) => {
   // delete brands
   client.query('SELECT * FROM product_images where id = $1', [1], function (err, result) {
       if (err) {
@@ -16,14 +14,14 @@ router.delete('/product-images', (req, res, next) => {
   });
 });
 
-router.post('/product-images', (req, res, next) => {
+router.post('/', (req, res, next) => {
   console.log("receive",req)
   // Employee.create(req.body.form).then((employee) => {
   //   res.status(200).json(employee);
   // });
 });
 
-router.get('/product-images', async(req, res, next) => {
+router.get('/', async(req, res, next) => {
   ProductImage.findAll({ include: ['ProductImageProduct']}).then((pimage) => {
       res.status(200).json(pimages);
     }).catch((err) => {

--- a/src/routes/productanswers/index.js
+++ b/src/routes/productanswers/index.js
@@ -1,22 +1,12 @@
 const router = require('express').Router();
 const cors = require('cors');
-const multer = require('multer');
-const fs = require('fs');
-const config = require('../../config.js');
 const verify = require('../verifyToken');
 const ProductAnswer = require('../../pg/models/ProductAnswers');
+const upload = require('../../middlewares/uploadArray');
 
 router.all('*', cors());
 
-var storage = multer.memoryStorage({
-  destination: function (req, file, cb) {
-    cb(null, '')
-  },
-})
-
-var upload = multer({ storage: storage }).array('image')
-
-router.delete('/productanswers/:id', verify, (req, res, next) => {
+router.delete('/:id', verify, (req, res, next) => {
   // delete brands
   ProductAnswer.findOne({ where: {id: req.params.id}})
   .then((answer) => {
@@ -37,7 +27,7 @@ router.delete('/productanswers/:id', verify, (req, res, next) => {
 });
 
 
-router.put('/productanswers/:id', [upload, verify], (req, res, next) => {
+router.put('/:id', [upload, verify], (req, res, next) => {
   const body = req.body;
   const id = req.params.id;
   const user = req.user.id;
@@ -63,7 +53,7 @@ router.put('/productanswers/:id', [upload, verify], (req, res, next) => {
   })
 });
 
-router.post('/productanswers', [upload, verify], (req, res, next) => {
+router.post('/', [upload, verify], (req, res, next) => {
   const body = req.body;
   const id = req.user.id;
   ProductAnswer.create({
@@ -78,7 +68,7 @@ router.post('/productanswers', [upload, verify], (req, res, next) => {
   })
 })
 
-router.get('/productanswers', async(req, res, next) => {
+router.get('/', async(req, res, next) => {
   // get statuses
   let userRole = null;
   if (req.query.id) {

--- a/src/routes/productquestions/index.js
+++ b/src/routes/productquestions/index.js
@@ -1,22 +1,12 @@
 const router = require('express').Router();
 const cors = require('cors');
-const multer = require('multer');
-const fs = require('fs');
-const config = require('../../config.js');
 const verify = require('../verifyToken');
 const ProductQuestion = require('../../pg/models/ProductQuestions');
+const upload = require('../../middlewares/uploadArray');
 
 router.all('*', cors());
 
-var storage = multer.memoryStorage({
-  destination: function (req, file, cb) {
-    cb(null, '')
-  },
-})
-
-var upload = multer({ storage: storage }).array('image')
-
-router.delete('/productquestions/:id', verify, (req, res, next) => {
+router.delete('/:id', verify, (req, res, next) => {
   // delete brands
   ProductQuestion.findOne({ where: {id: req.params.id}})
   .then((comment) => {
@@ -37,7 +27,7 @@ router.delete('/productquestions/:id', verify, (req, res, next) => {
 });
 
 
-router.put('/productquestions/:id', [verify, upload], (req, res, next) => {
+router.put('/:id', [verify, upload], (req, res, next) => {
   const body = req.body;
   const id = req.params.id;
   
@@ -62,7 +52,7 @@ router.put('/productquestions/:id', [verify, upload], (req, res, next) => {
   })
 });
 
-router.post('/productquestions', [verify, upload], (req, res, next) => {
+router.post('/', [verify, upload], (req, res, next) => {
   const body = req.body;
   ProductQuestion.create({
     'product': body.product,
@@ -75,7 +65,7 @@ router.post('/productquestions', [verify, upload], (req, res, next) => {
   })
 })
 
-router.get('/productquestions', async(req, res, next) => {
+router.get('/', async(req, res, next) => {
   // get statuses
   let data = null;
 

--- a/src/routes/products/index.js
+++ b/src/routes/products/index.js
@@ -1,15 +1,10 @@
 const router = require('express').Router();
 const cors = require('cors');
 const bodyParser = require('body-parser')
-const multer = require('multer');
-const fs = require('fs');
-const config = require('../../config.js');
-const data = require('../../samples/products.json');
 const verify = require('../verifyToken');
-
 const Product = require('../../pg/models/Products');
 const ProductImages = require('../../pg/models/ProductImages');
-
+const upload = require('../../middlewares/uploadArray');
 const AWS = require('aws-sdk');
 const uuid = require('uuid');
 
@@ -22,15 +17,7 @@ const s3 = new AWS.S3({
 
 router.all('*', cors());
 
-var storage = multer.memoryStorage({
-  destination: function (req, file, cb) {
-    cb(null, '')
-  },
-})
-
-var upload = multer({ storage: storage }).array('image')
-
-router.delete('/products/:id', verify, (req, res, next) => {
+router.delete('/:id', verify, (req, res, next) => {
   // delete products
   Product.findAll({ where: {id: req.params.id},include:['productImages','productVendor', 'productBrand', 'categories', 'productStatus', 'rates']})
   .then((product) => {
@@ -69,7 +56,7 @@ router.delete('/products/:id', verify, (req, res, next) => {
 });
 
 
-router.put('/products/:id', [verify, upload], (req, res, next) => {
+router.put('/:id', [verify, upload], (req, res, next) => {
 
 
   const imagesUploaded = req.files.map((file) => {
@@ -178,7 +165,7 @@ router.put('/products/:id', [verify, upload], (req, res, next) => {
   })
 });
 
-router.post('/products', [verify, upload], (req, res, next) => {
+router.post('/', [verify, upload], (req, res, next) => {
   // add / update products
 
   const imagesUploaded = req.files.map((file) => {
@@ -233,7 +220,7 @@ router.post('/products', [verify, upload], (req, res, next) => {
   })
 })
 
-router.post('/products/import', [verify, bodyParser.json()], (req, res, next) => {
+router.post('/import', [verify, bodyParser.json()], (req, res, next) => {
   const data = req.body;
   controller.importProducts(data, req.user.id).then((result) => {
     res.status(200).json({status: true, message: "Products imported"});
@@ -243,12 +230,12 @@ router.post('/products/import', [verify, bodyParser.json()], (req, res, next) =>
   });
 });
 
-router.get('/products/:id', async(req, res, next) => {
+router.get('/:id', async(req, res, next) => {
     let product = await Product.findAll({ where: {id: req.params.id}});
     res.json(product)
 });
 
-router.get('/products', async(req, res, next) => {
+router.get('/', async(req, res, next) => {
   // get products
   let product = null;
   

--- a/src/routes/statuses/index.js
+++ b/src/routes/statuses/index.js
@@ -1,19 +1,15 @@
 const router = require('express').Router();
 const cors = require('cors');
-const multer = require('multer');
-const fs = require('fs');
-const config = require('../../config.js');
-
 const Status = require('../../pg/models/Statuses');
 
 router.all('*', cors());
 
-router.get('/statuses/:id', async(req, res, next) => {
+router.get('/:id', async(req, res, next) => {
     let product = await Status.findAll({ where: {id: req.params.id}});
     res.json(product)
 });
 
-router.get('/statuses', async(req, res, next) => {
+router.get('/', async(req, res, next) => {
   // get statuses
   let product = null;
   if (req.query.id) {

--- a/src/routes/stores/index.js
+++ b/src/routes/stores/index.js
@@ -1,22 +1,12 @@
 const router = require('express').Router();
 const cors = require('cors');
-const multer = require('multer');
-const fs = require('fs');
-const config = require('../../config.js');
 const verify = require('../verifyToken');
 const Store = require('../../pg/models/Stores');
+const upload = require('../../middlewares/uploadSingle');
 
 router.all('*', cors());
 
-var storage = multer.memoryStorage({
-  destination: function (req, file, cb) {
-    cb(null, '')
-  },
-})
-
-var upload = multer({ storage: storage }).single('image')
-
-router.delete('/stores/:id', verify, (req, res, next) => {
+router.delete('/:id', verify, (req, res, next) => {
   // delete brands
   Store.findAll({ where: {id: req.params.id}})
   .then((store) => {
@@ -33,7 +23,7 @@ router.delete('/stores/:id', verify, (req, res, next) => {
 });
 
 
-router.put('/stores/:id', [verify, upload], (req, res, next) => {
+router.put('/:id', [verify, upload], (req, res, next) => {
   const body = req.body;
   const sid = req.params.id;
   Store.update(
@@ -65,7 +55,7 @@ router.put('/stores/:id', [verify, upload], (req, res, next) => {
   })
 });
 
-router.post('/stores',[verify, upload], (req, res, next) => {
+router.post('/',[verify, upload], (req, res, next) => {
   const body = req.body;
 
   Store.create({
@@ -83,12 +73,12 @@ router.post('/stores',[verify, upload], (req, res, next) => {
   })
 })
 
-router.get('/stores/:id', async(req, res, next) => {
+router.get('/:id', async(req, res, next) => {
     let store = await Store.findAll({ where: {id: req.params.id}});
     res.json(store)
 });
 
-router.get('/stores', async(req, res, next) => {
+router.get('/', async(req, res, next) => {
   // get products
   let store = null;
   if (req.query.id) {

--- a/src/routes/sweetBoxProducts/index.js
+++ b/src/routes/sweetBoxProducts/index.js
@@ -1,12 +1,10 @@
 const router = require('express').Router();
 const cors = require('cors');
-const config = require('../../config.js');
-
 const SweetBoxProduct = require('../../pg/models/SweetBoxProducts');
 
 router.all('*', cors());
 
-router.delete('/sweet-box-products', (req, res, next) => {
+router.delete('/', (req, res, next) => {
   // delete brands
   client.query('SELECT * FROM sweet_box_products where id = $1', [1], function (err, result) {
       if (err) {
@@ -16,7 +14,7 @@ router.delete('/sweet-box-products', (req, res, next) => {
   });
 });
 
-router.get('/sweet-box-products', async(req, res, next) => {
+router.get('/', async(req, res, next) => {
   SweetBoxProduct.findAll({include: ['sweetboxProductProduct', 'sweetboxProductStatus']}).then((pimage) => {
       res.status(200).json(pimages);
     }).catch((err) => {

--- a/src/routes/sweetBoxes/index.js
+++ b/src/routes/sweetBoxes/index.js
@@ -1,24 +1,12 @@
 const router = require('express').Router();
 const cors = require('cors');
-const multer = require('multer');
-const fs = require('fs');
-const config = require('../../config.js');
 const verify = require('../verifyToken');
-
 const SweetBox = require('../../pg/models/SweetBoxes');
+const upload = require('../../middlewares/uploadSingle');
 
 router.all('*', cors());
 
-var storage = multer.memoryStorage({
-  destination: function (req, file, cb) {
-    cb(null, '')
-  },
-})
-
-var upload = multer({ storage: storage }).single('image')
-
-
-router.get('/sweetboxes', async(req, res, next) => {
+router.get('/', async(req, res, next) => {
   // get statuses
   let sweetbox = null;
   if (req.query.id) {
@@ -38,7 +26,7 @@ router.get('/sweetboxes', async(req, res, next) => {
   }
 });
 
-router.post('/sweetboxes', [upload, verify], (req, res, next) => {
+router.post('/', [upload, verify], (req, res, next) => {
   const body = req.body;
   SweetBox.create({
     'name': body.name,
@@ -49,8 +37,7 @@ router.post('/sweetboxes', [upload, verify], (req, res, next) => {
   })
 })
 
-router.put('/sweetboxes/:id', [verify, upload], (req, res, next) => {
-  let dataInsert = null;
+router.put('/:id', [verify, upload], (req, res, next) => {
   const body = req.body;
   const bid = req.params.id;
   
@@ -74,7 +61,7 @@ router.put('/sweetboxes/:id', [verify, upload], (req, res, next) => {
   })
 });
 
-router.delete('/sweetboxes/:id', verify, (req, res, next) => {
+router.delete('/:id', verify, (req, res, next) => {
   // delete brands
   SweetBox.findAll({ where: {id: req.params.id}})
   .then((brand) => {

--- a/src/routes/useraddresses/index.js
+++ b/src/routes/useraddresses/index.js
@@ -1,23 +1,12 @@
 const router = require('express').Router();
 const cors = require('cors');
-const multer = require('multer');
-const fs = require('fs');
-const config = require('../../config.js');
 const verify = require('../verifyToken');
 const UserAddress = require('../../pg/models/UserAddresses');
-const User = require('../../pg/models/Users');
+const upload = require('../../middlewares/uploadSingle');
 
 router.all('*', cors());
 
-var storage = multer.memoryStorage({
-  destination: function (req, file, cb) {
-    cb(null, '')
-  },
-})
-
-var upload = multer({ storage: storage }).single('image')
-
-router.delete('/useraddresses/:id', verify, (req, res, next) => {
+router.delete('/:id', verify, (req, res, next) => {
   // delete brands
   UserAddress.findAll({ where: {id: req.params.id}})
   .then((address) => {
@@ -34,7 +23,7 @@ router.delete('/useraddresses/:id', verify, (req, res, next) => {
 });
 
 
-router.put('/useraddresses/:id', [verify, upload], (req, res, next) => {
+router.put('/:id', [verify, upload], (req, res, next) => {
   const body = req.body;
   const sid = req.params.id;
   const user = req.body && req.body.user ? req.body.user : req.user.id;
@@ -62,7 +51,7 @@ router.put('/useraddresses/:id', [verify, upload], (req, res, next) => {
   })
 });
 
-router.post('/useraddresses', [verify, upload], (req, res, next) => {
+router.post('/', [verify, upload], (req, res, next) => {
   const body = req.body;
   const user = req.body && req.body.user ? req.body.user : req.user.id;
 
@@ -84,7 +73,7 @@ router.post('/useraddresses', [verify, upload], (req, res, next) => {
   })
 })
 
-router.get('/useraddresses/:id', [verify, upload], async(req, res, next) => {
+router.get('/:id', [verify, upload], async(req, res, next) => {
   // get products
   console.log(req)
   const id = req.query.id;
@@ -101,7 +90,7 @@ router.get('/useraddresses/:id', [verify, upload], async(req, res, next) => {
   }
 });
 
-router.get('/useraddresses', [verify, upload], async(req, res, next) => {
+router.get('/', [verify, upload], async(req, res, next) => {
   // get products
   console.log(req)
   const user = req.user.id;
@@ -142,7 +131,7 @@ router.get('/useraddresses', [verify, upload], async(req, res, next) => {
 });
 
 // for admin
-router.get('/usersaddresses', [verify, upload], async(req, res, next) => {
+router.get('/', [verify, upload], async(req, res, next) => {
   // get products
   const user = req.body.user;
   

--- a/src/routes/userroles/index.js
+++ b/src/routes/userroles/index.js
@@ -1,14 +1,10 @@
 const router = require('express').Router();
 const cors = require('cors');
-const multer = require('multer');
-const fs = require('fs');
-const config = require('../../config.js');
-
 const UserRole = require('../../pg/models/UserRoles');
 
 router.all('*', cors());
 
-router.get('/userroles', async(req, res, next) => {
+router.get('/', async(req, res, next) => {
   // get statuses
   let userRole = null;
   if (req.query.id) {

--- a/src/routes/users/index.js
+++ b/src/routes/users/index.js
@@ -8,8 +8,9 @@ const bcrypt = require('bcryptjs');
 const User = require('../../pg/models/Users');
 const verify = require('../verifyToken');
 const AWS = require('aws-sdk');
-const Op = require('sequelize').Op
+const { Op } = require('sequelize');
 const uuid = require('uuid');
+const upload = require('../../middlewares/uploadSingle');
 
 const s3 = new AWS.S3({
   accessKeyId: process.env.AWS_ID,
@@ -18,17 +19,9 @@ const s3 = new AWS.S3({
 
 router.all('*', cors());
 
-var storage = multer.memoryStorage({
-  destination: function (req, file, cb) {
-    cb(null, '')
-  },
-})
-
-var upload = multer({ storage: storage }).single('image')
-
 const aw3Bucket = `${process.env.AWS_BUCKET_NAME}/users`;
 
-router.delete('/users/:id',verify, (req, res, next) => {
+router.delete('/:id',verify, (req, res, next) => {
   // delete brands
   User.findAll({ where: {id: req.params.id}, include:['user_addresses']})
   .then((user) => {
@@ -58,7 +51,7 @@ router.delete('/users/:id',verify, (req, res, next) => {
 });
 
 
-router.put('/users/:id',[verify,upload], (req, res, next) => {
+router.put('/:id',[verify,upload], (req, res, next) => {
   let dataInsert = null;
   const body = req.body;
   const id = req.params.id;
@@ -147,7 +140,7 @@ router.put('/users/:id',[verify,upload], (req, res, next) => {
   })
 });
 
-router.post('/users', [upload], (req, res, next) => {
+router.post('/', [upload], (req, res, next) => {
   let dataEntry = null;
   const body = req.body;
   const userRole = body.userRole ? body.userRole : 2;
@@ -208,12 +201,12 @@ router.post('/users', [upload], (req, res, next) => {
   });
 })
 
-router.get('/users/:id', [verify], async(req, res, next) => {
+router.get('/:id', [verify], async(req, res, next) => {
     let user = await User.findAll({ where: {id: req.params.id}});
     res.json(user)
 });
 
-router.get('/users', [verify], async(req, res, next) => {
+router.get('/', [verify], async(req, res, next) => {
   // get products
   let user = null;
   if (req.query.id) {
@@ -245,6 +238,5 @@ router.get('/users', [verify], async(req, res, next) => {
     }
   }
 });
-
 
 module.exports = router

--- a/src/routes/vendorrates/index.js
+++ b/src/routes/vendorrates/index.js
@@ -1,26 +1,15 @@
 const router = require('express').Router();
 const cors = require('cors');
-const multer = require('multer');
-const fs = require('fs');
-const config = require('../../config.js');
 const verify = require('../verifyToken');
-const ProductRate = require('../../pg/models/ProductRates');
+const VendorRate = require('../../pg/models/VendorRates');
 
 router.all('*', cors());
 
-var storage = multer.memoryStorage({
-  destination: function (req, file, cb) {
-    cb(null, '')
-  },
-})
-
-var upload = multer({ storage: storage }).array('image')
-
-router.delete('/productrates/:id', verify, (req, res, next) => {
+router.delete('/:id', verify, (req, res, next) => {
   // delete brands
-  ProductRate.findOne({ where: {id: req.params.id}})
+  VendorRate.findOne({ where: {id: req.params.id}})
   .then((comment) => {
-    ProductRate.destroy({
+    VendorRate.destroy({
       where: {
         id: comment.id
       }
@@ -37,10 +26,10 @@ router.delete('/productrates/:id', verify, (req, res, next) => {
 });
 
 
-router.put('/productrates/:id', [upload, verify], (req, res, next) => {
+router.put('/:id', [verify], (req, res, next) => {
   const body = req.body;
   const id = req.params.id;
-  ProductRate.update(
+  VendorRate.update(
     {
       'rate': body.rate,
       'title': body.title,
@@ -63,13 +52,12 @@ router.put('/productrates/:id', [upload, verify], (req, res, next) => {
   })
 });
 
-router.post('/productrates', [upload, verify], (req, res, next) => {
+router.post('/', [verify], (req, res, next) => {
   const body = req.body;
-  const id = req.user.id;
-  ProductRate.create({
-    'product': body.product,
+  VendorRate.create({
+    'vendor': body.vendor,
     'title': body.title,
-    'user': id,
+    'user': body.user,
     'comment': body.comment,
     'rate': body.rate,
   }).then((data) => {
@@ -79,49 +67,23 @@ router.post('/productrates', [upload, verify], (req, res, next) => {
   })
 })
 
-router.get('/productrates', async(req, res, next) => {
+router.get('/', async(req, res, next) => {
   // get statuses
   let data = null;
   if (req.query.id) {
     try {
-      data = await ProductRate.findOne({ where: {id: req.query.id}});
+      data = await VendorRate.findOne({ where: {id: req.query.id}});
       res.json(data)
     } catch(err) {
       res.send({status: false, message: err})
     }
   } else {
     try {
-      data = await ProductRate.findAll();
+      data = await VendorRate.findAll();
       res.json(data)
     } catch(err) {
       res.send({status: false, message: err})
     }
-  }
-});
-
-router.get('/productallrates', async(req, res, next) => {
-  // get statuses
-  const limit = req.query.limit ? req.query.limit : null;
-
-  let data = null;
-  if (req.query.id) {
-    try {
-      const query = limit ? { 
-        limit,
-        where: {productId: req.query.id}, 
-        include: ['rateUsers', 'rateProduct', 'rateStatus']
-      } : {
-        where: {productId: req.query.id}, 
-        include: ['rateUsers', 'rateProduct', 'rateStatus']
-      }
-      console.log("jquery", query);
-      data = await ProductRate.findAll(query);
-      res.json(data)
-    } catch(err) {
-      res.send({})
-    }
-  } else { 
-      res.send({})
   }
 });
 

--- a/src/routes/wishlists/index.js
+++ b/src/routes/wishlists/index.js
@@ -1,22 +1,12 @@
 const router = require('express').Router();
 const cors = require('cors');
-const multer = require('multer');
-const fs = require('fs');
-const config = require('../../config.js');
 const verify = require('../verifyToken');
 const UserWishlist = require('../../pg/models/UserWishlists');
+const upload = require('../../middlewares/uploadArray');
 
 router.all('*', cors());
 
-var storage = multer.memoryStorage({
-  destination: function (req, file, cb) {
-    cb(null, '')
-  },
-})
-
-var upload = multer({ storage: storage }).array('image')
-
-router.delete('/wishlists/:id', verify, (req, res, next) => {
+router.delete('/:id', verify, (req, res, next) => {
   // delete brands
   UserWishlist.findOne({ where: {id: req.params.id}})
   .then((comment) => {
@@ -37,7 +27,7 @@ router.delete('/wishlists/:id', verify, (req, res, next) => {
 });
 
 
-router.put('/wishlists/:id', [upload, verify], (req, res, next) => {
+router.put('/:id', [upload, verify], (req, res, next) => {
   const body = req.body;
   const id = req.params.id;
   const user = req.user.id;
@@ -62,7 +52,7 @@ router.put('/wishlists/:id', [upload, verify], (req, res, next) => {
   })
 });
 
-router.post('/wishlists', [upload, verify], (req, res, next) => {
+router.post('/', [upload, verify], (req, res, next) => {
   const body = req.body;
   const user = req.user.id;
   UserWishlist.create({
@@ -75,7 +65,7 @@ router.post('/wishlists', [upload, verify], (req, res, next) => {
   })
 })
 
-router.get('/wishlists', async(req, res, next) => {
+router.get('/', async(req, res, next) => {
   // get statuses
   let data = null;
   if (req.query.id) {
@@ -95,7 +85,7 @@ router.get('/wishlists', async(req, res, next) => {
   }
 });
 
-router.delete('/userwishlists/:id', verify, (req, res, next) => {
+router.delete('/user/:id', verify, (req, res, next) => {
   // delete brands
   const user = req.user.id;
 
@@ -117,7 +107,7 @@ router.delete('/userwishlists/:id', verify, (req, res, next) => {
   })
 });
 
-router.get('/userwishlists', [verify], async(req, res, next) => {
+router.get('/user', [verify], async(req, res, next) => {
   // get statuses
   const user = req.user.id;
   if (req.query.product) {

--- a/src/routes/workroles/index.js
+++ b/src/routes/workroles/index.js
@@ -1,19 +1,15 @@
 const router = require('express').Router();
 const cors = require('cors');
-const multer = require('multer');
-const fs = require('fs');
-const config = require('../../config.js');
-
 const WorkRole = require('../../pg/models/WorkRoles');
 
 router.all('*', cors());
 
-router.get('/workroles/:id', async(req, res, next) => {
+router.get('/:id', async(req, res, next) => {
     let workRole = await WorkRole.findAll({ where: {id: req.params.id}});
     res.json(workRole)
 });
 
-router.get('/workroles', async(req, res, next) => {
+router.get('/', async(req, res, next) => {
   // get statuses
   let workRole = null;
   if (req.query.id) {


### PR DESCRIPTION
This is not a massive change, but it scares a bit, because 29 files have changed.  Some routes directory cases have changed.  Since the way the folder names, and the route was not kind of standardized, some standardizations were done here.  So, if the route will for the **endpoint is sweet-box, then the folder should be sweetBox**, so the route autoloader will automatically pickup the directory name of sweetBox, and will convert it to sweet-box route.  Some cases were valid, but some other cases not, for example, we had a productRates folder, but the route assigned was productrates.  So it was like a mixed bag.  So directories were renamed, to accommodate how the api is being used in the client.  Also, where were some inconsistent route names being used in a directory that did not match, so that was changed also.  There's a PR for the client UI that has modifications taking these changes into account.  For example, **productallrates** route under productrates directory is now /productrates/all , which makes more sense and it's better structured this way, you have your root /productrates and you want /all rates, so that's /produtrates/all.  There were like 3 api endpoints that had this type of inconsistency and were changed.

So, for these directory case changes, if you update, the directories I think they might now change the case, unless you pull it clean I think.  Might be tricky if you already pulled out the code before this one, after merged (if merged).  Or manually rename the directories to match the correct case.

So the standard for the routes auto loader is, if there is a camel cased directory or capitalized letter, it will add a - at the front and lower case them all.  Example, **productrates** is the directory name, then it will create a route **/productrates**. If the directory is **productImages**, then it will create a route **/product-images**.

Also you no longer need to add on the route definitions the directory name, since the route autoloader will pick the root route name from the directory name, so you no longer have to define your routes as **/productrates/:id** under a **productrates** directory inside **routes**.  You only need to define it as **/:id**, and that should be enough.

Some unused libraries declarations were deleted, most of them.  Also, some common repeated code for defining the storage using memory for image as a single or array thing, those were moved into a **middlewares** directory, since that **upload** is actually use as a middleware for the routes.  I think maybe the verifyToken.js that's in that routes directory should also be moved into the **middlewares** directory, since it is also a middleware.  Maybe in a next commit or change.