### PR TITLE
Hooks library improvements. Wrapped callHooks in case it's sending to…

### DIFF
--- a/src/hooks.js
+++ b/src/hooks.js
@@ -13,7 +13,7 @@ function createHooks() {
     // Creating hooks that will be used for invoices
     // createHook(HOOKNAMES.ORDER, ['create', 'update', 'delete']);
     // Creating hooks that will be used for stock updates
-    createHook(HOOKNAMES.INVENTORY, ['create', 'update', 'delete']);
+    // createHook(HOOKNAMES.INVENTORY, ['create', 'update', 'delete']);
 }
 
 function listenUserHooks() {

--- a/src/utils/hooks/index.js
+++ b/src/utils/hooks/index.js
@@ -2,6 +2,53 @@ const EventEmitter = require('events');
 const AsyncFunction = (async function() {}).constructor;
 const ERROR_EVENTNAME = 'error';
 const eventEmitters = {};
+const listeners = {};
+
+/** Creates a tracking object that stores the original listener and the wrapped one */
+const createListenerObject = (wrappedFunction, listenerFunction) => {
+    return {
+        wrappedFunction: wrappedFunction,
+        originalListener: listenerFunction
+    }
+}
+
+const getTrackedListener = (hookName, eventName, listener) => {
+    if (!listeners[hookName]) {
+        throw Error(`No hook with name of ${hookName}.`);
+    }
+    if (!listeners[hookName][eventName]) {
+        throw Error(`No event name ${eventName} for hook ${hookName}. Cannot remove the given look listener`);
+    }
+    return listeners[hookName][eventName].find(to => to.originalListener === listener);
+}
+
+/** Adds the wrapped listener reference to tracking object */
+const trackListener = (hookName, eventName, listenerObject) => {
+    if (!listeners[hookName]) {
+        listeners[hookName] = {}
+    }
+    if (!listeners[hookName][eventName]) {
+        listeners[hookName][eventName] = []
+    }
+    listeners[hookName][eventName].push(listenerObject);
+}
+
+/** Removes listener reference from tracking object */
+const untrackListener = (hookName, eventName, listenerObject) => {
+    if (!listeners[hookName]) {
+        throw Error(`No hook with name of ${hookName}. Cannot untrack the given hook listener`);
+    }
+    if (!listeners[hookName][eventName]) {
+        throw Error(`No event name ${eventName} for hook ${hookName}. Cannot untrack the given hook listener`);
+    }
+    if (listeners[hookName][eventName]) {
+        const listenersArray = listeners[hookName][eventName];
+        const index = listenersArray.indexOf(listenerObject);
+        if (index > -1) {
+            listenersArray.splice(index, 1);
+        }
+    }
+}
 
 /**
  * Creates a hook with the given hookName that will have the given array of events.
@@ -31,31 +78,50 @@ const createHook = (hookName, events) => {
  * @param {function} func 
  */
 const listenHook = (hookName, eventName, func) => {
-    if (eventEmitters[hookName]) {
-        const ee = eventEmitters[hookName];
+    const ee = getHook(hookName);
+    if (ee) {
         if (ee.allowedEventNames.includes(eventName)) {
+            let wrappedFunction = null;
             // If it is async, wrap around, so an error can be emitted if it has an exception
             if (func instanceof AsyncFunction) {
-                // Doing this might make difficult to remove the listener
-                ee.emitter.on(eventName, async function(...args) {
+                wrappedFunction = async function(...args) {
                     try {
                         await func(...args)
                     } catch (error) {
                         // Emit an error
                         ee.emitter.emit(ERROR_EVENTNAME, error);
                     }
-                });
+                }
+                ee.emitter.on(eventName, wrappedFunction);
             } else {
-                ee.emitter.on(eventName, func);
+                wrappedFunction = function(...args) {
+                    try {
+                        func(...args);
+                    } catch (error) {
+                        ee.emitter.emit(ERROR_EVENTNAME, error);
+                    }
+                }
+                ee.emitter.on(eventName, wrappedFunction);
             }
+            // Track the given listener function
+            trackListener(hookName, eventName, createListenerObject(wrappedFunction, func));
         } else {
             throw Error(`Event name ${eventName} not part of allowed event names on hook: ${hookName}`);
         }
-    } else {
-        throw Error(`Hook with name ${hookName} does not exist`);
     }
 }
 
+/** Removes the given listener function from the given hook name and event name */
+const removeFromHook = (hookName, eventName, func) => {
+    const trackedListener = getTrackedListener(hookName, eventName, func);
+    if (trackedListener) {
+        const hook = getHook(hookName);
+        hook.emitter.off(eventName, trackedListener.wrappedFunction);
+        untrackListener(hookName, eventName, trackedListener);
+    }
+}
+
+/** Gets the hook object for the given name */
 const getHook = (hookName) => {
     if (eventEmitters[hookName]) {
         return eventEmitters[hookName];
@@ -70,15 +136,15 @@ const getHook = (hookName) => {
  * @param  {...any} args 
  */
 const callHook = (hookName, eventName, ...args) => {
-    if (!eventEmitters[hookName]) {
-        throw Error(`Hook with name ${hookName} does not exist`);
+    const hook = getHook(hookName);
+    if (hook) {
+        hook.emit(eventName, ...args);
     }
-    eventEmitters[hookName].emit(eventName, ...args);
 }
 
 module.exports = {
     createHook,
     listenHook,
-    getHook,
+    removeFromHook,
     callHook
 }


### PR DESCRIPTION
… invalid hookname

Updated the hooks unit tests. Wrapped the callHook in services in another function to catch the exception that is thrown if there are no hooks configured for the given hook name, because the hook library will throw an exception if you call something that is not configured