### PR TITLE
Fixes stock update when admin edits order

### DIFF
--- a/src/hooks.js
+++ b/src/hooks.js
@@ -1,7 +1,7 @@
 const { createHook, listenHook } = require('./utils/hooks');
 const HOOKNAMES = require('./constants/hooknames');
 const { createCustomer, updateCustomer, deleteCustomer } = require('./integrations/quickbooks/hooks/user');
-// const { createInvoice, updateInvoice, deleteInvoice } = require('./integrations/quickbooks/hooks/invoice');
+const { createInvoice, updateInvoice, deleteInvoice } = require('./integrations/quickbooks/hooks/invoice');
 // const { createInventory, updateInventory, deleteInventory } = require('./integrations/quickbooks/hooks/inventory');
 
 /**
@@ -11,7 +11,7 @@ function createHooks() {
     // Creating hooks that will be used by user creation for the given events
     createHook(HOOKNAMES.USER, ['create', 'update', 'delete']);
     // Creating hooks that will be used for invoices
-    // createHook(HOOKNAMES.ORDER, ['create', 'update', 'delete']);
+    createHook(HOOKNAMES.ORDER, ['create', 'update', 'delete']);
     // Creating hooks that will be used for stock updates
     // createHook(HOOKNAMES.INVENTORY, ['create', 'update', 'delete']);
 }
@@ -23,11 +23,11 @@ function listenUserHooks() {
     listenHook(HOOKNAMES.USER, 'delete', deleteCustomer);
 }
 
-// function listenOrderHooks() {
-//     listenHook(HOOKNAMES.ORDER, 'create', createInvoice);
-//     listenHook(HOOKNAMES.ORDER, 'update', updateInvoice);
-//     listenHook(HOOKNAMES.ORDER, 'delete', deleteInvoice);
-// }
+function listenOrderHooks() {
+    listenHook(HOOKNAMES.ORDER, 'create', createInvoice);
+    listenHook(HOOKNAMES.ORDER, 'update', updateInvoice);
+    listenHook(HOOKNAMES.ORDER, 'delete', deleteInvoice);
+}
 
 // function listenInventoryHooks() {
 //     listenHook(HOOKNAMES.INVENTORY, 'create', createInventory);
@@ -42,7 +42,7 @@ function configureHooks() {
     createHooks();
     listenUserHooks();
     // listenInventoryHooks();
-    // listenOrderHooks();
+    listenOrderHooks();
 }
 
 module.exports = configureHooks;

--- a/src/integrations/quickbooks/hooks/invoice.js
+++ b/src/integrations/quickbooks/hooks/invoice.js
@@ -112,26 +112,26 @@ function convertOrderToInvoice(order, customerRefId) {
 }
 
 async function createInvoice(order, user) {
-    const exists = await integrationExists(INTEGRATIONS.QUICKBOOKS);
-    if (exists) {
-        const customerRef = await getCustomerRef(user.id);
-        if (customerRef) {
-            const service = new QuickbooksService();
-            const qbCustomerRef = customerRef.external_id;
-            const invoice = convertOrderToInvoice(order, qbCustomerRef);
-            try {
-                await service.init();
-                const newInvoice = await service.createInvoice(invoice);
-                const invoiceRef = await saveInvoiceRef(orderId, newInvoice.Invoice.Id);
-                log.info('Quickbooks Invoice created', { invoice: newInvoice, invoiceRef });
-            } catch (error) {
-                log.error('Error creating invoice in Quickbooks', error);
-            }
-        } else {
-            log.error(`Cannot create an invoice without a valid customer from Quickbooks, no customer reference found for ${user.id}`);
-        }
+    // const exists = await integrationExists(INTEGRATIONS.QUICKBOOKS);
+    // if (exists) {
+    //     const customerRef = await getCustomerRef(user.id);
+    //     if (customerRef) {
+    //         const service = new QuickbooksService();
+    //         const qbCustomerRef = customerRef.external_id;
+    //         const invoice = convertOrderToInvoice(order, qbCustomerRef);
+    //         try {
+    //             await service.init();
+    //             const newInvoice = await service.createInvoice(invoice);
+    //             const invoiceRef = await saveInvoiceRef(orderId, newInvoice.Invoice.Id);
+    //             log.info('Quickbooks Invoice created', { invoice: newInvoice, invoiceRef });
+    //         } catch (error) {
+    //             log.error('Error creating invoice in Quickbooks', error);
+    //         }
+    //     } else {
+    //         log.error(`Cannot create an invoice without a valid customer from Quickbooks, no customer reference found for ${user.id}`);
+    //     }
         
-    }
+    // }
 }
 
 async function updateInvoice(order) {

--- a/src/services/product.stock.service.js
+++ b/src/services/product.stock.service.js
@@ -16,9 +16,13 @@ const getStockAmount = (stockQty, quantity, stockMode = STOCK_MODE.DECREASE) => 
     }
 }
 
-/** Updates the stock based on the given products from order */
+/**
+ * Updates the stock based on the given products from order
+ * This will deduct or increase, so if it is an existing order, it is going to mess up with the stock
+ */
 const updateStock = async (orderProductsArray, { transaction, stockMode = STOCK_MODE.DECREASE }) => {
     const pids = orderProductsArray.map(op => +op.productItem);
+    // This cannot read uncommited changes
     const productItemsToUpdate = await ProductItem.findAll({ where: { id: { [Op.in]: pids } } });
 
     const stocksToUpdate = [];


### PR DESCRIPTION
An admin updating an order should revert the stocks for the order products first by readding them back, and then deducting from stock with the new order product stock value. What it was doing before, it was always deducting when updating the order, so if the order got updated multiple times, it might be deducting a lot from stock.